### PR TITLE
Fix: Limit calculator output to 3 decimal places

### DIFF
--- a/web_cal.js
+++ b/web_cal.js
@@ -1,21 +1,23 @@
 const display = document.getElementById("display");
 
-function appendToDisplay(input){
+function appendToDisplay(input) {
     display.value += input;
 }
 
-function clearDisplay(){
+function clearDisplay() {
     display.value = "";
 }
 
-function calculate(){
+function calculate() {
     try {
-        display.value = eval(display.value);
+        let result = eval(display.value);
+        
+        result = Math.round(result * 1000) / 1000; 
+        
+        display.value = result;
+        
         display.scrollLeft = display.scrollWidth;
+    } catch (error) {
+        display.value = "Error";
     }
-
-    catch (error){
-        display.value = "Error"
-    }
-    
 }


### PR DESCRIPTION
# Description
This pull request addresses an issue where the calculator displayed results with too many decimal places, making it hard to read. The output is now limited to 3 decimal places for better usability and precision.

# Details of the Fix
Modified the calculate() function in the JavaScript code.
Used the Math.round() method to round the result to 3 decimal places before displaying it.
Updated the display to show the formatted result without affecting other features of the calculator.

<hr>

![image](https://github.com/user-attachments/assets/d8913936-9402-4678-8e5a-e08fcfb8e726)

<hr>

# How to Test
Enter a calculation that results in a long decimal output, e.g., 5 / 6 or 10 / 3.
Verify that the result is displayed with a maximum of 3 decimal places, e.g., 0.833 or 3.333